### PR TITLE
Implement Notion codex page rendering

### DIFF
--- a/frontend-clean/components/Control_Components/CodexCard.jsx
+++ b/frontend-clean/components/Control_Components/CodexCard.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export default function CodexCard({ title, updated, content }) {
+  return (
+    <div className="theme-scroll-card rounded-xl p-6 space-y-3 bg-black text-white">
+      <h2 className="text-lg font-semibold">{title}</h2>
+      <p className="text-xs theme-muted">{new Date(updated).toLocaleString()}</p>
+      <pre className="whitespace-pre-wrap theme-muted text-sm">{content}</pre>
+    </div>
+  )
+}

--- a/frontend-clean/components/SmartRenderer.jsx
+++ b/frontend-clean/components/SmartRenderer.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import ScrollCard from './Control_Components/ScrollCard.jsx'
+import CodexCard from './Control_Components/CodexCard.jsx'
+import { inferTypeFromTitle } from '../lib/notion.js'
+
+export default function SmartRenderer({ title, updated, content }) {
+  const type = inferTypeFromTitle(title)
+
+  if (type === 'Scroll') {
+    return (
+      <ScrollCard
+        emoji="📜"
+        title={title}
+        description={content}
+      />
+    )
+  }
+
+  if (type === 'Codex') {
+    return <CodexCard title={title} updated={updated} content={content} />
+  }
+
+  return (
+    <div className="theme-card bg-black text-white rounded-xl p-6 space-y-3">
+      <h2 className="text-lg font-semibold">{title}</h2>
+      <p className="text-xs theme-muted">{new Date(updated).toLocaleString()}</p>
+      <pre className="whitespace-pre-wrap theme-muted text-sm">{content}</pre>
+    </div>
+  )
+}

--- a/frontend-clean/pages/codex.js
+++ b/frontend-clean/pages/codex.js
@@ -1,46 +1,20 @@
-import { useState } from 'react'
-import { fetchCodexPageByTitle } from '../lib/notion.js'
+import SmartRenderer from '../components/SmartRenderer.jsx'
+import { fetchPageById } from '../lib/notion.js'
 
-export default function Codex() {
-  const [title, setTitle] = useState('')
-  const [result, setResult] = useState(null)
-  const [error, setError] = useState('')
-
-  async function handleFetch() {
-    setError('')
-    setResult(null)
-    try {
-      const res = await fetch(`/api/fetch-codex?title=${encodeURIComponent(title)}`)
-      if (!res.ok) throw new Error(await res.text())
-      const data = await res.json()
-      setResult(data)
-    } catch (err) {
-      setError(err.message)
-    }
+export default function CodexPage({ page }) {
+  if (!page) {
+    return <div className="text-center p-6">Page not found.</div>
   }
 
   return (
-    <div className="p-6 max-w-xl mx-auto">
-      <h1 className="text-3xl font-bold mb-4">Fetch Codex Page</h1>
-      <input
-        className="border p-2 w-full mb-2"
-        placeholder="Enter page title (e.g. Self Systems)"
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
-      />
-      <button className="bg-blue-500 text-white px-4 py-2" onClick={handleFetch}>
-        Fetch Page
-      </button>
-      {error && <p className="text-red-500 mt-2">{error}</p>}
-      {result && (
-        <div className="mt-6">
-          <h2 className="text-2xl font-bold">{result.title}</h2>
-          <p className="text-gray-500 text-sm">
-            Last updated: {new Date(result.updated).toLocaleString()}
-          </p>
-          <pre className="mt-4 whitespace-pre-wrap">{result.content}</pre>
-        </div>
-      )}
-    </div>
+    <main className="bg-black text-white min-h-screen flex items-center justify-center p-6">
+      <SmartRenderer title={page.title} updated={page.updated} content={page.content} />
+    </main>
   )
+}
+
+export async function getServerSideProps() {
+  const pageId = process.env.PAGE_ID
+  const page = await fetchPageById(pageId)
+  return { props: { page } }
 }


### PR DESCRIPTION
## Summary
- fetch page content by ID using Notion SDK
- smart type inference and rendering
- add Codex card component
- new `/codex.js` page using getServerSideProps

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684553066450832084e5dd29781ce4ce